### PR TITLE
fix: accept "golang" too

### DIFF
--- a/mise/golang.json
+++ b/mise/golang.json
@@ -11,8 +11,8 @@
 				"mise/config.toml$"
 			],
 			"matchStrings": [
-				"golang\\s*=\\s*\"v?(?<currentValue>\\S+)\"\\s*#\\s*renovate:\\s*mise",
-				"golang\\s*=\\s*'v?(?<currentValue>\\S+)'\\s*#\\s*renovate:\\s*mise"
+				"go(?:lang)?\\s*=\\s*\"v?(?<currentValue>\\S+)\"\\s*#\\s*renovate:\\s*mise",
+				"go(?:lang)?\\s*=\\s*'v?(?<currentValue>\\S+)'\\s*#\\s*renovate:\\s*mise"
 			],
 			"datasourceTemplate": "github-tag",
 			"depNameTemplate": "golang/go"

--- a/test/mise/golang.test.ts
+++ b/test/mise/golang.test.ts
@@ -28,17 +28,22 @@ describe("golang", () => {
 	const testCases = [
 		{
 			it: 'should parse quote with "',
-			input: 'golang = "1.21.6"  # renovate: mise',
+			input: 'go = "1.21.6"  # renovate: mise',
+			currentValue: "1.21.6",
+		},
+		{
+			it: 'should accept "golang" too',
+			input: 'go = "1.21.6"  # renovate: mise',
 			currentValue: "1.21.6",
 		},
 		{
 			it: "should perse even if it includes 'v' too",
-			input: 'golang = "v1.21.6"  # renovate: mise',
+			input: 'go = "v1.21.6"  # renovate: mise',
 			currentValue: "1.21.6",
 		},
 		{
 			it: "should perse even if it is quoted with single quote too",
-			input: "golang = '1.22.0'  # renovate: mise",
+			input: "go = '1.22.0'  # renovate: mise",
 			currentValue: "1.22.0",
 		},
 	] as const;


### PR DESCRIPTION
mise seems like to accept `go` and `golang` as tool name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated variable naming in the Go language test suite for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->