### PR TITLE
fix: replace current value to gox.x.x

### DIFF
--- a/mise/golang.json
+++ b/mise/golang.json
@@ -14,6 +14,7 @@
 				"go(?:lang)?\\s*=\\s*\"v?(?<currentValue>\\S+)\"\\s*#\\s*renovate:\\s*mise",
 				"go(?:lang)?\\s*=\\s*'v?(?<currentValue>\\S+)'\\s*#\\s*renovate:\\s*mise"
 			],
+			"currentValueTemplate": "go{{{ currentValue }}}",
 			"datasourceTemplate": "github-tags",
 			"depNameTemplate": "golang/go"
 		}


### PR DESCRIPTION
Currently go release it self as `gox.x.x`.

https://github.com/golang/go/tags
