### PR TITLE
chore: move personal config from renovate-config

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":timezone(Asia/Tokyo)",
+    ":semanticCommits"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>Omochice/renovate-config"]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
 	$schema: "https://docs.renovatebot.com/renovate-schema.json",
 	extends: [
-    "github>Omochice/renovate-config",
+    "github>Omochice/personal-renovate-config",
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+	$schema: "https://docs.renovatebot.com/renovate-schema.json",
+	extends: [
+    "github>Omochice/renovate-config",
+  ],
+}


### PR DESCRIPTION
ref: https://github.com/Omochice/renovate-config/pull/47
- **feat: add my personal configuration**
- **chore: rename internal config json to json5**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Renovate configuration settings to improve package update rules and automerge settings.
	- Extended Renovate configuration from a specific GitHub repository for enhanced management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->