### PR TITLE
feat: add custom manager for `pnpm.executeEnv.nodeVersion`

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           run_install: true
       - name: run test
-        run: pnpm test
+        run: pnpm run test

--- a/default.json
+++ b/default.json
@@ -7,7 +7,8 @@
 		"github>Omochice/personal-renovate-config//biomejs",
 		"github>Omochice/personal-renovate-config//mise",
 		"github>Omochice/personal-renovate-config//playwright",
-		"github>Omochice/personal-renovate-config//replacement"
+		"github>Omochice/personal-renovate-config//replacement",
+		"github>Omochice/personal-renovate-config//pnpm-nodeversion"
 	],
 	"packageRules": [
 		{

--- a/pnpm-nodeversion.json
+++ b/pnpm-nodeversion.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"customManagers": [
+		{
+			"customType": "jsonata",
+			"fileFormat": "json",
+			"fileMatch": ["package.json$"],
+			"matchStrings": ["{ 'currentValue': pnpm.executionEnv.nodeVersion }"],
+			"datasourceTemplate": "node-version",
+			"depNameTemplate": "node"
+		}
+	]
+}


### PR DESCRIPTION
Support over 39.145 because it use jsonata.

https://github.com/renovatebot/renovate/commit/fc8b8f9b61d09460d51fbd515e45a90b8cec8305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected configuration formatting to ensure reliable processing.
- **New Features**
  - Integrated an additional configuration option for automated Node.js version management in package updates.
  - Added a new configuration file for custom Node.js versioning management.
  - Specified the package manager version in the package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->