### PR TITLE
style: format JSONata expression in matchStrings

### DIFF
--- a/biomejs.json
+++ b/biomejs.json
@@ -7,7 +7,7 @@
 			"depNameTemplate": "@biomejs/biome",
 			"fileFormat": "json",
 			"managerFilePatterns": ["/(^|/)biome\\.jsonc?$/"],
-			"matchStrings": ["{'currentValue': $split($.'$schema', ('/'))[-2]}"]
+			"matchStrings": ["{'currentValue': $split($.'$schema', '/')[-2]}"]
 		}
 	]
 }


### PR DESCRIPTION
Add space after comma in $split function call to improve readability
and maintain consistent formatting with standard coding conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minor formatting adjustment to a JSON expression in configuration (string literal formatting only); no change to runtime behavior.
  * No additions, removals, or modifications to exported/public interfaces or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->