### PR TITLE
feat: add pnpm grouping rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,6 +15,7 @@
 		"github>Omochice/personal-renovate-config//pnpm-nodeversion#v1.15.0",
 		"github>Omochice/personal-renovate-config//grouping/devbox#v1.15.0",
 		"github>Omochice/personal-renovate-config//grouping/knip#v1.15.0",
+		"github>Omochice/personal-renovate-config//grouping/pnpm#v1.16.0",
 		"github>Omochice/personal-renovate-config//grouping/slidev#v1.15.0",
 		"github>Omochice/personal-renovate-config//grouping/takumi-js#v1.15.0",
 		"github>Omochice/personal-renovate-config//replacement/release-please-action.json#v1.15.0",

--- a/grouping/pnpm.json
+++ b/grouping/pnpm.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"description": "Grouping rule for pnpm",
+	"packageRules": [
+		{
+			"groupName": "pnpm",
+			"matchPackageNames": ["pnpm", "ghcr.io/pnpm/pnpm"]
+		}
+	]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Renovate grouping configuration to group `pnpm` and `ghcr.io/pnpm/pnpm` updates together for easier review.
  * Bumped the referenced Renovate preset version for the `pnpm` grouping rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->