### PR TITLE
feat: manage $schema version in knip config files

### DIFF
--- a/grouping/knip.json
+++ b/grouping/knip.json
@@ -1,6 +1,24 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Grouping rule for knip",
+	"description": "Grouping rule and $schema version management for knip",
+	"customManagers": [
+		{
+			"customType": "jsonata",
+			"fileFormat": "json",
+			"managerFilePatterns": [
+				"**/knip.json",
+				"**/knip.jsonc",
+				"**/.knip.json",
+				"**/.knip.jsonc"
+			],
+			"matchStrings": [
+				"{ 'currentValue': $contains($.'$schema', 'knip@') ? $substringBefore($substringAfter($.'$schema', 'knip@'), '/') : undefined }"
+			],
+			"datasourceTemplate": "npm",
+			"depNameTemplate": "knip",
+			"depTypeTemplate": "devDependencies"
+		}
+	],
 	"packageRules": [
 		{
 			"groupName": "knip monorepo",


### PR DESCRIPTION
## Summary

Let Renovate update the version embedded in the `$schema` URL of knip config files.

## Details

A knip config carries its own version inside the schema URL, such as `https://unpkg.com/knip@6.29.0/schema.json`, so updating only the `knip` package leaves the schema behind.

Keeping the JSONata custom manager in the same file as the existing grouping rule makes the `knip monorepo` group carry the `$schema` bump and the package bump in one PR, which is what keeps the two in sync.

## Confirmation

Confirmed that `renovate-config-validator --strict` passes and that the correct version is extracted from real knip configs on this machine (`knip@5`, `knip@6`, `knip@6.29.0`, and a `.knip.jsonc` using `schema-jsonc.json`).

Evaluated the globs with the same minimatch options Renovate uses (`dot: true`, `nocase: true`) and confirmed they match nested configs while rejecting `knip.config.ts` and `knip.json5`.

## Limitation

This takes effect for consumers only after the `#v1.16.0` pin in `default.json` is bumped following a release.

JS/TS configs such as `knip.config.ts` and the `knip` key in `package.json` are out of scope, since neither carries a `$schema` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPeR6mH1bG5kyqMHLzcXL4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated tracking and management of the Knip schema version.
  * Updated project configuration documentation to reflect schema version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->